### PR TITLE
fix: update getAlbumAssets() for Immich v3 compatibility

### DIFF
--- a/public/ImmichApi.php
+++ b/public/ImmichApi.php
@@ -63,7 +63,7 @@ class ImmichApi {
 
     /**
      * Get album assets
-     * 
+     *
      * @param string $album_id Album ID
      * @return array List of album assets
      * @throws Exception If there's an error in the request
@@ -73,57 +73,74 @@ class ImmichApi {
             throw new InvalidArgumentException('Album ID is required');
         }
 
-        $url = "{$this->immich_url}/api/albums/{$album_id}";
-        $ch = curl_init($url);
-        
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            "x-api-key: {$this->api_key}",
-            "Accept: application/json"
-        ]);
-
-        $response = curl_exec($ch);
-        if ($response === false) {
-            $error = "Error: " . curl_error($ch);
-            error_log($error);
-            throw new Exception($error);
-        }
-
-        $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-        if ($http_code !== 200 || $response === false) {
-            $error = "HTTP error $http_code when connecting to Immich $response";
-            error_log($error);
-            throw new Exception($error);
-        }
-
-        $data = json_decode($response, true);
-        
-        if (!is_array($data) || !isset($data['assets'])) {
-            $error = "Invalid response from Immich: $response";
-            error_log($error);
-            throw new Exception($error);
-        }
-
+        // Immich v3 removed assets from GET /api/albums/{id}.
+        // Use POST /api/search/metadata with albumIds instead, paginating until done.
         $photos = [];
-        foreach ($data['assets'] as $asset) {
-            if (!isset($asset['id']) || $asset['isArchived'] || $asset['isTrashed']) {
-                continue;
+        $page = 1;
+
+        do {
+            $url = "{$this->immich_url}/api/search/metadata";
+            $body = json_encode([
+                'albumIds' => [$album_id],
+                'size' => 1000,
+                'page' => $page,
+            ]);
+
+            $ch = curl_init($url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, [
+                "x-api-key: {$this->api_key}",
+                "Accept: application/json",
+                "Content-Type: application/json"
+            ]);
+
+            $response = curl_exec($ch);
+            if ($response === false) {
+                $error = "Error: " . curl_error($ch);
+                error_log($error);
+                throw new Exception($error);
             }
 
-            // Determine orientation based on image dimensions
-            $orientation = 'landscape';
-            if (isset($asset['exifInfo']['exifImageHeight']) && isset($asset['exifInfo']['exifImageWidth'])) {
-                if ($asset['exifInfo']['exifImageHeight'] > $asset['exifInfo']['exifImageWidth']) {
-                    $orientation = 'portrait';
+            $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+            if ($http_code !== 200) {
+                $error = "HTTP error $http_code when connecting to Immich $response";
+                error_log($error);
+                throw new Exception($error);
+            }
+
+            $data = json_decode($response, true);
+
+            if (!is_array($data) || !isset($data['assets']['items'])) {
+                $error = "Invalid response from Immich: $response";
+                error_log($error);
+                throw new Exception($error);
+            }
+
+            foreach ($data['assets']['items'] as $asset) {
+                if (!isset($asset['id']) || $asset['isArchived'] || $asset['isTrashed']) {
+                    continue;
                 }
+
+                // Determine orientation based on image dimensions (v3 exposes these as top-level fields)
+                $orientation = 'landscape';
+                if (isset($asset['height']) && isset($asset['width'])) {
+                    if ($asset['height'] > $asset['width']) {
+                        $orientation = 'portrait';
+                    }
+                }
+
+                $photos[] = [
+                    'id' => $asset['id'],
+                    'orientation' => $orientation
+                ];
             }
 
-            $photos[] = [
-                'id' => $asset['id'],
-                'orientation' => $orientation
-            ];
-        }
+            $nextPage = $data['assets']['nextPage'] ?? null;
+            $page = $nextPage !== null ? (int)$nextPage : null;
+        } while ($page !== null);
 
         return $photos;
     }


### PR DESCRIPTION
## Problem

Immich v3 removed the assets list from `GET /api/albums/{id}`. The album
endpoint now only returns album metadata — not the asset list — so
`getAlbumAssets()` was receiving a response with no `assets` key and
returning an empty array, breaking the slideshow entirely.

## Changes

**`public/ImmichApi.php` — `getAlbumAssets()` only**

- Replaces the single `GET /api/albums/{id}` call with a paginated
  `POST /api/search/metadata` request using `albumIds`
- Handles pagination via `assets.nextPage` so albums with more than
  1000 assets are fully fetched
- Updates orientation detection to read from the top-level `width`/`height`
  fields that v3 now exposes directly on each asset, instead of
  `exifInfo.exifImageWidth/Height`
- All existing filtering logic (`isArchived`, `isTrashed`) is unchanged
- No other files are modified — `GET /api/albums` and
  `GET /api/assets/{id}/thumbnail` are unaffected by v3

## Testing

Validated against a live Immich v3.0.1 instance by querying
`POST /api/search/metadata` directly via the API explorer and confirming
the response shape matches what the updated code expects.

A pre-built Docker image is available to test without building from source:

docker pull ghcr.io/dhruvb14/immich-slideshow-old-devices:pr-1

You can also review the full diff and discussion in the working branch PR:
dhruvb14/immich-slideshow-old-devices#1

The reason you see additional files in PR link above vs this PR to your repo is because I wanted to build and push to my own Github container registry incase you choose to not approve this PR, I still need it working on my iPads again.